### PR TITLE
Add integration.md and sync package-lock version to 1.0.0

### DIFF
--- a/integration.md
+++ b/integration.md
@@ -1,0 +1,21 @@
+# Snoozify
+
+## Purpose
+A Chrome extension that snoozes browser tabs to reopen them on a chosen day. Works entirely locally — no account, no external servers, no tracking.
+
+## Where it runs
+- **Environment**: Chrome browser extension
+- **Dev**: Load unpacked from repo root in Chrome (`chrome://extensions` → Load unpacked)
+- **Production**: Published on the Chrome Web Store (v1.0.0)
+
+## Deployment
+Chrome Web Store publishing — package the extension and upload via the Chrome Developer Dashboard. Dev workflow uses `web-ext` for auto-reload (see `dev-setup.sh`).
+
+## Dependencies & integrations
+- Chrome Extension APIs: `alarms`, `storage`, `tabs`
+- No external services or databases
+
+## Gotchas
+- Manifest V3 extension — uses service workers, not background pages
+- Hold Shift (and Alt) to see snooze options for the following week
+- Export/import JSON is the only backup mechanism for snooze data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snoozify",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snoozify",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.7",
         "c8": "^9.1.0",


### PR DESCRIPTION
## Summary
- Adds `integration.md` with deployment, API, and gotchas context for the my-services registry
- Syncs `package-lock.json` version from `0.1.0` to `1.0.0` to match `package.json`

## Test Plan
- [ ] All 24 unit tests pass (`npm test`)